### PR TITLE
Fix for std::is_infinite namespace with gcc, include directory fix for Kangaroo

### DIFF
--- a/applications/kinectfusion/CMakeLists.txt
+++ b/applications/kinectfusion/CMakeLists.txt
@@ -4,7 +4,8 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/CMakeModules/")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x -g")
 
 find_package(Kangaroo 0.1 REQUIRED)
-include_directories(${Kangaroo_INCLUDE_DIRS})
+
+include_directories(${Kangaroo_INCLUDE_DIRS} ${PROJECT_SOURCE_DIR})
 link_libraries(${Kangaroo_LIBRARIES})
 
 # git clone git://github.com/arpg/Pangolin.git

--- a/kangaroo/MarchingCubes.h
+++ b/kangaroo/MarchingCubes.h
@@ -58,7 +58,7 @@ void vMarchCube(
     float afCubeValue[8];
     for(int iVertex = 0; iVertex < 8; iVertex++) {
         afCubeValue[iVertex] = vol.Get(x+a2fVertexOffset[iVertex][0],y+a2fVertexOffset[iVertex][1],z+a2fVertexOffset[iVertex][2]);
-#ifdef _MSVC_
+#if defined _MSVC_ || defined __GNUC__
         if(!std::isfinite(afCubeValue[iVertex])) return;
 #else
         if(!isfinite(afCubeValue[iVertex])) return;
@@ -102,7 +102,7 @@ void vMarchCube(
             const float3 deriv = vol.GetUnitsBackwardDiffDxDyDz( asEdgeVertex[iEdge] );
             asEdgeNorm[iEdge] = deriv / length(deriv);
 
-#ifdef _MSVC_
+#if defined _MSVC_ || defined __GNUC__
             if( !std::isfinite(asEdgeNorm[iEdge].x) || !std::isfinite(asEdgeNorm[iEdge].y) || !std::isfinite(asEdgeNorm[iEdge].z) ) {
 #else
             if( !isfinite(asEdgeNorm[iEdge].x) || !isfinite(asEdgeNorm[iEdge].y) || !isfinite(asEdgeNorm[iEdge].z) ) {


### PR DESCRIPTION
1) Now checking whether compiler is GCC to prepend ```is_infinite``` with the ```std::``` namespace in case the compiler is gcc.

2) PROJECT_SOURCE_DIR now added to the include_directories of the KinectFusion application in CMake (previously, it could not find headers inside the kangaroo folder)

(Takes care of #7)